### PR TITLE
不必要な変数削除・再デプロイ

### DIFF
--- a/src/features/graph/hooks/useChartsOptions.ts
+++ b/src/features/graph/hooks/useChartsOptions.ts
@@ -1,26 +1,12 @@
 import { useState } from "react";
-import {
-  PopulationCompositionDict,
-  PopulationLabel,
-} from "../../../types/population";
-import { PrefectureDict, PrefectureIsChecked } from "../../../types/prefecture";
+import { PopulationLabel } from "../../../types/population";
 import { makeHighChartsOptions } from "../utils/makehighChartsOptions";
 import { allFalsePrefectureIsChecked } from "../../../mocks/allFalsePrefectureIsChecked";
 import { populationCompositionDict11Only } from "../../../mocks/populationCompositionDict11Only";
 import prefectureDict_ from "../../../mocks/prefectureDict";
 
-export type UseChartsOptionsPayload = {
-  prefectureIsChecked: PrefectureIsChecked;
-  populationCompositionDict: PopulationCompositionDict;
-  prefectureDict: PrefectureDict;
-};
-
 // グラフ用オプション作成。
-export const useChartsOptions = (
-  prefectureIsChecked: PrefectureIsChecked,
-  populationCompositionDict: PopulationCompositionDict,
-  prefectureDict: PrefectureDict,
-) => {
+export const useChartsOptions = () => {
   // ラベル
   // セレクトボックスで状態操作を行う
   // 現時点では総人口で固定

--- a/src/features/graph/routes/GraphArea.tsx
+++ b/src/features/graph/routes/GraphArea.tsx
@@ -11,16 +11,8 @@ type GraphAreaProps = {
 };
 
 // グラフのエリアのコンポーネント
-export const GraphArea: React.FC<GraphAreaProps> = ({
-  prefectureIsChecked,
-  populationCompositionDict,
-  prefectureDict,
-}) => {
-  const { options } = useChartsOptions(
-    prefectureIsChecked,
-    populationCompositionDict,
-    prefectureDict,
-  );
+export const GraphArea: React.FC<GraphAreaProps> = () => {
+  const { options } = useChartsOptions();
 
   return (
     <div>


### PR DESCRIPTION
#7 のmainへのマージでビルド・デプロイに失敗したため、eslintの警告に対応