### PR TITLE
apiキー入力を1つの画面に統合

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,11 @@
-import { Route, Routes, BrowserRouter } from "react-router-dom";
 import { PrefecturePopulationPage } from "./pages/PrefecturePopulationPage";
-import { ApiKeyInputPage } from "./pages/ApiKeyInputPage";
 import { ResasApiKeyProvider } from "./provider/ResasApiKey";
-import { RequireApiKey } from "./routes/RequireApiKey";
 import "./global.scss";
 
 const App = () => {
   return (
     <ResasApiKeyProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route
-            path="/"
-            element={
-              <RequireApiKey>
-                <PrefecturePopulationPage />
-              </RequireApiKey>
-            }
-          />
-          <Route path="/apikey" element={<ApiKeyInputPage />} />
-        </Routes>
-      </BrowserRouter>
+      <PrefecturePopulationPage />
     </ResasApiKeyProvider>
   );
 };

--- a/src/features/prefectures/hooks/useHandleCheckboxClick.ts
+++ b/src/features/prefectures/hooks/useHandleCheckboxClick.ts
@@ -58,7 +58,7 @@ export const useHandleCheckboxClick = (
           });
       }
     },
-    [populationCompositionDict, setPopulationCompositionDict],
+    [populationCompositionDict, setPopulationCompositionDict, apiKey],
   );
   return handleCheckboxClick;
 };

--- a/src/hooks/usePrefecture.ts
+++ b/src/hooks/usePrefecture.ts
@@ -44,12 +44,12 @@ export const usePrefecture = () => {
       .catch((e: AxiosError<{ error: string }>) => {
         console.log(e.message);
       });
-  }, [setPrefectureDict, setPrefectureIsChecked]);
+  }, [setPrefectureDict, setPrefectureIsChecked, apiKey]);
 
   // 初回レンダリング時に都道府県一覧データの取得と各種変数の初期化
   useEffect(() => {
     void getPrefectures();
-  }, []);
+  }, [apiKey]);
 
   return {
     prefectureDict,

--- a/src/pages/ApiKeyInputPage.tsx
+++ b/src/pages/ApiKeyInputPage.tsx
@@ -1,40 +1,34 @@
 import { useCallback, useState, useContext } from "react";
 import { SetResasApiKeyContext } from "../provider/ResasApiKey";
-import { useNavigate } from "react-router-dom";
-import { route } from "../routes/route";
 
 export const ApiKeyInputPage = () => {
   const [apiKeyInput, setApiKeyInput] = useState(""); // コンポーネント内のみのapiキーのstate
   const setApiKey = useContext(SetResasApiKeyContext); // コンテキストとしてapiキー情報を保持
-  const navigate = useNavigate();
 
   // 利用開始ボタン押下時の処理
-  // apiキーをcontextに格納し、都道府県人口グラフのページに遷移する
+  // apiキーをcontextに格納する
   const handleSubmit = useCallback(() => {
     setApiKey(apiKeyInput);
-    navigate(route.prefecturePopulationPage);
-  }, [apiKeyInput, navigate, route]);
+  }, [apiKeyInput]);
 
   return (
     <div>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <h2>RESAS APIキー</h2>
-        </div>
-        <div>API呼び出しに使用するRESAS APIキーを指定します。</div>
-        <div>
-          <input
-            type="password"
-            placeholder="RESAS-APIキー"
-            value={apiKeyInput}
-            required
-            onChange={(e) => setApiKeyInput(e.target.value)}
-          />
-        </div>
-        <div>
-          <input type="submit" value="利用開始" />
-        </div>
-      </form>
+      <div>
+        <h2>RESAS APIキー</h2>
+      </div>
+      <div>API呼び出しに使用するRESAS APIキーを指定します。</div>
+      <div>
+        <input
+          type="password"
+          placeholder="RESAS-APIキー"
+          value={apiKeyInput}
+          required
+          onChange={(e) => setApiKeyInput(e.target.value)}
+        />
+      </div>
+      <div>
+        <input type="submit" value="利用開始" onClick={handleSubmit} />
+      </div>
     </div>
   );
 };

--- a/src/pages/PrefecturePopulationPage.tsx
+++ b/src/pages/PrefecturePopulationPage.tsx
@@ -1,6 +1,7 @@
 import { GraphArea } from "../features/graph";
 import { PrefectureCheckList } from "../features/prefectures";
 import { usePrefecture } from "../hooks/usePrefecture";
+import { ApiKeyInputPage } from "./ApiKeyInputPage";
 
 export const PrefecturePopulationPage = () => {
   // 初期化・State作成
@@ -15,6 +16,7 @@ export const PrefecturePopulationPage = () => {
   return (
     <div>
       <h1>都道府県人口グラフ</h1>
+      <ApiKeyInputPage />
       <PrefectureCheckList
         prefectureDict={prefectureDict}
         setPrefectureIsChecked={setPrefectureIsChecked}


### PR DESCRIPTION
## 概要
Github pagesのデフォルトの設定の場合、ReactでSPAの構築を行うと該当しない擬似的なパスへのアクセスで404が発生する。
適切にルーティングを行うためには時間がかかるので現時点では1つの画面でAPIキーの入力も行う形に変更。