### PR TITLE
GitHub ActionsのdeployワークフローのbuildジョブにおけるURLの削除

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,6 @@ jobs:
   build:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub Actionsのdeployワークフローのbuildジョブにおいて、URLの警告が出現していた。
今回ビルドの時点ではサイトのURLを表示する必要はあまりないため、削除する