### PR TITLE
manifest.json内のlogoに関する記述を削除

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
以前create react appによるデフォルトのlogoを削除したが、manifest.jsonに該当するlogoの記述が残っていたためエラーが出現していた。
該当する記述を削除した。